### PR TITLE
Increase small copy font size

### DIFF
--- a/web_modules/InANutshell/index.css
+++ b/web_modules/InANutshell/index.css
@@ -11,14 +11,14 @@
 
 .title {
   color: #3f526b;
-  font-size: 26px;
+  font-size: 28px;
   font-weight: lighter;
   line-height: 32px;
 }
 
 .body {
   color: color(#48463e a(84%));
-  font-size: 13px;
+  font-size: 14px;
   line-height: 20px;
   margin-top: 1rem;
 }

--- a/web_modules/Showcase/index.css
+++ b/web_modules/Showcase/index.css
@@ -25,7 +25,7 @@
 
 .callToAction {
   color: #3f526b;
-  font-size: 12px;
+  font-size: 13px;
   font-style: italic;
   line-height: 20px;
   margin: 2rem auto 0;

--- a/web_modules/Showcase/index.js
+++ b/web_modules/Showcase/index.js
@@ -40,10 +40,10 @@ export default function Showcase() {
             className={ styles.logo }
             src={ taobao }
           />
-        </li>  
+        </li>
       </ul>
       <p className={ styles.callToAction }>
-        { "Your company is using PostCSS? " }
+        { "Is your company using PostCSS? " }
         <a
           className={ styles.letUsKnow }
           href="https://twitter.com/postcss"


### PR DESCRIPTION
Ref: https://github.com/postcss/postcss.org/issues/138

I tried 16px, but it:

a. Dramatically threw off the vertical rhythm with everything else.
b. Created very short and uncomfortable line lengths on small viewports.

So, I’ve bump it to 14px, from 13px for `InANutshell` and 13px, from
12px, for `Showcase.

Personally I think what we have here is a good compromise, but if it’s
not acceptable then this one might need to go back to the design board.