### PR TITLE
Background opacity fix for social component

### DIFF
--- a/web_modules/Social/index.css
+++ b/web_modules/Social/index.css
@@ -46,7 +46,7 @@
 
 @media (width > 580px) {
   .root {
-    background-color: color(black a(30%));
+    background-color: color(black a(40%));
     margin-top: 0;
     position: absolute;
     right: 0;


### PR DESCRIPTION
The current background of the social component is a slightly different color/opacity than its adjacent component: Nav, when on Desktop view.

![opacity-diff](https://cloud.githubusercontent.com/assets/9411730/12967120/75adbc8a-d029-11e5-806c-7ba185863cd3.png)
Hiding the dark hero image illustrates this better:
![opacity-diff-elaborate](https://cloud.githubusercontent.com/assets/9411730/12967136/89da3184-d029-11e5-92ca-b1aadc04e3b7.png)

I just changed the social component's background to match the nav component's background on desktop.