### PR TITLE
Fix "undefined" values in meta tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "private": true,
+  "name": "PostCSS",
   "homepage": "http://postcss.org/",
+  "twitter": "PostCSS",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore . && stylelint web_modules/**/*.css",
     "eslint-staged": "eslint-staged",


### PR DESCRIPTION
Some of the meta tags in the head are currently showing "undefined"

How its currently rendering:
```html
<meta data-react-helmet="true" property="og:site_name" content="undefined">
<meta data-react-helmet="true" name="twitter:site" content="@undefined">
<meta data-react-helmet="true" content="@undefined" name="twitter:creator">
```
This was because "name" and "twitter" were missing from package.

After adding to package.json:
```html
<meta data-react-helmet="true" content="PostCSS" property="og:site_name">
<meta data-react-helmet="true" content="@PostCSS" name="twitter:site">
<meta data-react-helmet="true" content="@PostCSS" name="twitter:creator">
```