### PR TITLE
Fix overflow issue in ByTheCommunity

### DIFF
--- a/web_modules/ByTheCommunity/index.css
+++ b/web_modules/ByTheCommunity/index.css
@@ -8,6 +8,7 @@
   height: 340px;
   justify-content: center;
   padding: 0 1rem;
+  overflow-x: hidden;
 }
 
 .title {

--- a/web_modules/ByTheCommunity/index.css
+++ b/web_modules/ByTheCommunity/index.css
@@ -8,7 +8,7 @@
   height: 340px;
   justify-content: center;
   padding: 0 1rem;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .title {


### PR DESCRIPTION
Addresses #185 

Turns out it wasn't a mobile viewport bug but the contributors avatars overflowing out of the container.

Adding `overflow-x: hidden` to the root seems to do the trick.

My first PR so be gentle :)