### PR TITLE
 "Use tomorrow's CSS, today!" not fully shown

### DIFF
--- a/web_modules/InANutshell/index.css
+++ b/web_modules/InANutshell/index.css
@@ -55,14 +55,14 @@
   position: relative;
   display: flex;
   flex-direction: column-reverse;
-  margin-right: 2rem;
+  margin-right: 1.1rem;
   overflow: hidden;
 }
 
 .figureOutput {
   composes: figure;
   flex-direction: column;
-  margin-left: 2rem;
+  margin-left: 1.1rem;
   margin-right: 0;
   transform: translateY(-1rem);
 }


### PR DESCRIPTION
Example "Use tomorrow's CSS, today!" doesnt show the closing bracket (")") and the semicolon (";")

reduce the margin-right and margin-left to fully show example