### PR TITLE
Consistent styling for Error Page (404 page) 

### DIFF
--- a/web_modules/InANutshell/index.js
+++ b/web_modules/InANutshell/index.js
@@ -159,13 +159,13 @@ export default function InANutShell() {
               </h2>
             </header>
             <p className={ styles.body }>
-             <a
-               className={ styles.tool }
-               href="https://github.com/css-modules/css-modules"
-             >
-               { "CSS Modules" }
-             </a>
-             { " means you never need to worry about your names being too generic, just use whatever makes the most sense." }
+              <a
+                className={ styles.tool }
+                href="https://github.com/css-modules/css-modules"
+              >
+                { "CSS Modules" }
+              </a>
+              { " means you never need to worry about your names being too generic, just use whatever makes the most sense." }
             </p>
           </div>
           <div className={ styles.example }>

--- a/web_modules/layouts/PageError/index.css
+++ b/web_modules/layouts/PageError/index.css
@@ -1,4 +1,44 @@
-.inner {
-  max-width: 50rem;
-  margin: 2rem auto;
+.item {
+  background: #faf8f5;
+  padding: 2rem 1rem;
+}
+
+.itemInner {
+  margin: 0 auto;
+  max-width: 45rem;
+}
+
+.body {
+  color: #636870;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  margin-top: 1rem;
+}
+
+.error {
+  font-size: 1rem;
+}
+
+.title {
+  color: #3f526b;
+  font-size: 1.5625rem;
+  font-weight: lighter;
+  line-height: 1.28;
+}
+
+.link {
+  color: inherit;
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+  }
+}
+
+.redirectMessage {
+  color: #3f526b;
+  font-size: 0.9375rem;
+  font-style: 300;
+  margin-top: 2rem;
+  text-align: center;
 }

--- a/web_modules/layouts/PageError/index.js
+++ b/web_modules/layouts/PageError/index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react"
+import { Link } from "react-router"
 import Helmet from "react-helmet"
 import Hero from "../../Hero"
 
@@ -15,6 +16,12 @@ export default class PageError extends Component {
     errorText: "Page Not Found",
   };
 
+  renderNotFoundError(error) {
+    if (error === 404) {
+      return <span>{ "The page you requested was not found." }</span>
+    }
+  }
+
   render() {
     const {
       error,
@@ -30,22 +37,31 @@ export default class PageError extends Component {
 
         <Hero />
 
-        <div className={ styles.inner }>
-          <h2>{ 'Whooops!' }</h2>
-            <p>
-              <strong>{ error }</strong>
-              { ' ' }
-              { errorText }
+        <section className={ styles.item }>
+          <div className={ styles.itemInner }>
+            <header>
+              <h2 className={ styles.title }>
+                { "Whooops!" }
+              </h2>
+            </header>
+            <p className={ styles.body }>
+              <strong className={ styles.error }>{ error }</strong>
+              { " " }
+              { errorText } <br/>
+              { this.renderNotFoundError(error) } <br />
             </p>
-            {
-              error === 404 &&
-                <div>
-                  <p>
-                    { 'The page you requested was not found.' }
-                  </p>
-                </div>
-            }
-        </div>
+            <p className={ styles.redirectMessage }>
+              { "Return to the " }
+              <Link
+                to="/"
+                className={ styles.link }
+              >
+                { "homepage" }
+              </Link>
+            </p>
+          </div>
+        </section>
+
       </main>
     )
   }


### PR DESCRIPTION
I have applied the same style from `<InANutShell />` to the error page. To do so I have created a shared styles folder under web_modules/app, similarly to how it is done in this [CSS Modules demo](https://css-modules.github.io/webpack-demo/) (See StyleVariantA.css)

I didn't want to refactor any more code before getting some feedback if this style is acceptable, let me know what you think

![image](https://cloud.githubusercontent.com/assets/325644/14401266/12277a0c-fe14-11e5-9989-3b315ff85663.png)
