### PR TITLE
Solve a11y issue on highlighted code

### DIFF
--- a/web_modules/InANutshell/index.css
+++ b/web_modules/InANutshell/index.css
@@ -85,7 +85,6 @@
 
 .highlight {
   background: #fff478;
-  color: white;
   display: inline-block;
   margin: 0.125rem 0;
   padding: 0.125rem;


### PR DESCRIPTION
Before this change, when **JavaScript is disabled**, the font-color of elements with class `highlight` was white on yellow background, which was hard to read. With this change it inherits parent color which is a black-ish color and therefore easier to read (see screenshots attached).
Before:
![postcss-a11y-issue-before](https://cloud.githubusercontent.com/assets/8432168/14427043/de6a5424-fff2-11e5-8795-9afc557236f4.PNG)
After:
![postcss-a11y-issue_after](https://cloud.githubusercontent.com/assets/8432168/14427042/de484f3c-fff2-11e5-8ed9-5f6a99f036a6.PNG)

