### PR TITLE
Fix favicon type

### DIFF
--- a/web_modules/LayoutContainer/index.js
+++ b/web_modules/LayoutContainer/index.js
@@ -65,7 +65,7 @@ export default class LayoutContainer extends Component {
               },
               {
                 "rel": "shortcut icon",
-                "type": "image/png",
+                "type": "image/x-icon",
                 "href": favicon,
               },
 


### PR DESCRIPTION
Hi, `"icon/png"` is not correct type of `.ico` favicons. Use `"image/x-icon"` instead of this:
http://stackoverflow.com/questions/13827325/correct-mime-type-for-favicon-ico