### PR TITLE
fix(index): Correct Autoprefixer pseudo‑class example

### DIFF
--- a/web_modules/InANutshell/index.js
+++ b/web_modules/InANutshell/index.js
@@ -57,15 +57,15 @@ export default function InANutShell() {
                   <span className={ styles.highlight }>
                     { "-webkit-" }
                   </span>
-                  { ":full-screen {" }<br />
+                  { "full-screen {" }<br />
                   { "}" }<br />
                   { ":" }
                   <span className={ styles.highlight }>
                     { "-moz-" }
                   </span>
-                  { ":full-screen {" }<br />
+                  { "full-screen {" }<br />
                   { "}" }<br />
-                  { ":full-screen {" }<br />
+                  { ":fullscreen {" }<br />
                   { "}" }<br />
                 </Highlight>
               </pre>


### PR DESCRIPTION
```css
:fullscreen {
}
```
gets auto‑prefixed to:
```css
:-webkit-full-screen {
}
:-moz-full-screen {
}
:fullscreen {
}
```
instead of:
```css
:-webkit-:full-screen {
}
:-moz-:full-screen {
}
:full-screen {
}
```