### PR TITLE
Add Collapsibles to API Page

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 specifiers:
   '@logux/eslint-config': ^47.2.0
@@ -54,11 +54,11 @@ dependencies:
   vite-plugin-pug-transformer: 1.0.1_vite@2.9.6
 
 devDependencies:
-  '@logux/eslint-config': 47.2.0_4nplxmjvkgcnqocjmji457cfg4
+  '@logux/eslint-config': 47.2.0_e35ebbb1355184d838496251cefc4537
   '@logux/stylelint-config': 0.10.0_stylelint@14.8.1
   '@size-limit/file': 7.0.8_size-limit@7.0.8
   eslint: 8.14.0
-  eslint-config-standard: 17.0.0_csxqpghp2u36zpehgl7g6fmctq
+  eslint-config-standard: 17.0.0_14af0798efd537ecbc8732fe6f15829c
   eslint-plugin-import: 2.26.0_eslint@8.14.0
   eslint-plugin-n: 15.2.0_eslint@8.14.0
   eslint-plugin-prefer-let: 3.0.1
@@ -138,7 +138,7 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
-  /@logux/eslint-config/47.2.0_4nplxmjvkgcnqocjmji457cfg4:
+  /@logux/eslint-config/47.2.0_e35ebbb1355184d838496251cefc4537:
     resolution: {integrity: sha512-nNPPkw+kfA2bLyhkxaqGzd3MWSN4S2dUf69xo2syskBd5ZfFk2WT9ssO+yDDUd26yNgN3AmweKztEwyUim9wOQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -150,7 +150,7 @@ packages:
       eslint-plugin-promise: ^6.0.0
     dependencies:
       eslint: 8.14.0
-      eslint-config-standard: 17.0.0_csxqpghp2u36zpehgl7g6fmctq
+      eslint-config-standard: 17.0.0_14af0798efd537ecbc8732fe6f15829c
       eslint-plugin-import: 2.26.0_eslint@8.14.0
       eslint-plugin-n: 15.2.0_eslint@8.14.0
       eslint-plugin-prefer-let: 3.0.1
@@ -1203,7 +1203,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /eslint-config-standard/17.0.0_csxqpghp2u36zpehgl7g6fmctq:
+  /eslint-config-standard/17.0.0_14af0798efd537ecbc8732fe6f15829c:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
       eslint: ^8.0.1

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -86,7 +86,7 @@ function link(cls, hash, text) {
   return tag(`a.${cls}`, { href: `#${hash}` }, text)
 }
 
-function arrow() {
+function controller() {
   let attrs = {
     onClick: `if (this.parentElement.nextSibling.style.display == 'block') {
       this.parentElement.nextSibling.style.display = 'none'
@@ -96,7 +96,7 @@ function arrow() {
       this.children[0].style.transform = 'rotate(90deg)'
     }`
   }
-  return tag(`button.sidemenu_arrow`, attrs, `<p>></p>`)
+  return tag(`button.sidemenu_controller`, attrs, ``)
 }
 
 function getName(node) {
@@ -148,7 +148,7 @@ function generateSidemenu(nodes) {
         }
         return tag(
           'li',
-          tag('div.sidemenu_control', [name, arrow()]) +
+          tag('div.sidemenu_bar', [name, controller()]) +
             tag(
               'ul.sidemenu_children',
               children

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -87,7 +87,16 @@ function link(cls, hash, text) {
 }
 
 function arrow() {
-  return tag(`button.sidemenu_arrow`, `>`)
+  let attrs = {
+    onClick: `if (this.parentElement.nextSibling.style.display == 'block') {
+      this.parentElement.nextSibling.style.display = 'none'
+      this.style.transform = 'rotate(0)'
+    } else {
+      this.parentElement.nextSibling.style.display = 'block'
+      this.style.transform = 'rotate(90deg)'
+    }`
+  }
+  return tag(`button.sidemenu_arrow`, attrs, `>`)
 }
 
 function getName(node) {

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -90,13 +90,13 @@ function arrow() {
   let attrs = {
     onClick: `if (this.parentElement.nextSibling.style.display == 'block') {
       this.parentElement.nextSibling.style.display = 'none'
-      this.style.transform = 'rotate(0)'
+      this.children[0].style.transform = 'rotate(0)'
     } else {
       this.parentElement.nextSibling.style.display = 'block'
-      this.style.transform = 'rotate(90deg)'
+      this.children[0].style.transform = 'rotate(90deg)'
     }`
   }
-  return tag(`button.sidemenu_arrow`, attrs, `>`)
+  return tag(`button.sidemenu_arrow`, attrs, `<p>></p>`)
 }
 
 function getName(node) {

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -86,6 +86,10 @@ function link(cls, hash, text) {
   return tag(`a.${cls}`, { href: `#${hash}` }, text)
 }
 
+function arrow() {
+  return tag(`button.sidemenu_arrow`, `>`)
+}
+
 function getName(node) {
   if (node.name === 'default') {
     if (node.kindString === 'Class') {
@@ -135,9 +139,9 @@ function generateSidemenu(nodes) {
         }
         return tag(
           'li',
-          name +
+          tag('div.sidemenu_control', [name, arrow()]) +
             tag(
-              'ul',
+              'ul.sidemenu_children',
               children
                 .filter(child => child.name !== 'constructor')
                 .map(child => {

--- a/src/nav/nav.pug
+++ b/src/nav/nav.pug
@@ -10,7 +10,7 @@ nav.nav
       a.nav_link( href="http://postcss.parts/" )
         | Plugins
     li.nav_item
-      a.nav_link( href="http://postcss.org/api/" )
+      a.nav_link( href="/api/" )
         | API
     li.nav_item
       a.nav_link( href="https://github.com/postcss/brand" )

--- a/src/sidemenu/sidemenu.pcss
+++ b/src/sidemenu/sidemenu.pcss
@@ -47,6 +47,9 @@
   background: #faf8f5;
   border-style: none;
   opacity: 0.5;
+}
+
+.sidemenu_arrow > p {
   transition-duration: 150ms;
 }
 
@@ -58,4 +61,8 @@
 .sidemenu_child:hover,
 .sidemenu_arrow:hover {
   background: #fff;
+}
+
+.sidemenu_arrow:hover {
+  opacity: 1;
 }

--- a/src/sidemenu/sidemenu.pcss
+++ b/src/sidemenu/sidemenu.pcss
@@ -18,11 +18,12 @@
   text-decoration: none;
 }
 
-.sidemenu_section {
+.sidemenu_section, .sidemenu_arrow {
   padding: 0.4rem 0 0.4rem 1rem;
   margin-top: 0.5rem;
   font-weight: bold;
   color: #3f526b;
+  flex-grow: 1;
 }
 
 .sidemenu_child {
@@ -32,7 +33,26 @@
   color: #3f526b;
 }
 
+.sidemenu_control {
+  display: flex;
+  flex-direction: row;
+}
+
+.sidemenu_arrow {
+  padding: 0.4rem 1rem 0.4rem 1rem;
+  flex-grow: 0;
+  border-style: none;
+  background: #faf8f5;
+  cursor: pointer;
+}
+
+.sidemenu_children {
+  display: none;
+}
+
 .sidemenu_section:hover,
-.sidemenu_child:hover {
+.sidemenu_child:hover,
+.sidemenu_arrow:hover
+{
   background: #fff;
 }

--- a/src/sidemenu/sidemenu.pcss
+++ b/src/sidemenu/sidemenu.pcss
@@ -19,8 +19,8 @@
 }
 
 .sidemenu_section,
-.sidemenu_arrow {
-  flex-grow: 1;
+.sidemenu_controller {
+  flex-grow: 0;
   padding: 0.4rem 0 0.4rem 1rem;
   margin-top: 0.5rem;
   font-weight: bold;
@@ -34,22 +34,21 @@
   color: #3f526b;
 }
 
-.sidemenu_control {
+.sidemenu_bar {
   display: flex;
   flex-direction: row;
 }
 
-.sidemenu_arrow {
-  flex-grow: 0;
+.sidemenu_controller {
+  flex-grow: 1;
   padding: 0.4rem 1rem;
   font-weight: 300;
   cursor: pointer;
-  background: #faf8f5;
   border-style: none;
-  opacity: 0.5;
+  opacity: 0;
 }
 
-.sidemenu_arrow > p {
+.sidemenu_controller > p {
   transition-duration: 150ms;
 }
 
@@ -57,12 +56,11 @@
   display: none;
 }
 
-.sidemenu_section:hover,
 .sidemenu_child:hover,
-.sidemenu_arrow:hover {
+.sidemenu_bar:hover {
   background: #fff;
 }
 
-.sidemenu_arrow:hover {
-  opacity: 1;
+.sidemenu_section:hover {
+  text-decoration: underline;
 }

--- a/src/sidemenu/sidemenu.pcss
+++ b/src/sidemenu/sidemenu.pcss
@@ -44,6 +44,9 @@
   border-style: none;
   background: #faf8f5;
   cursor: pointer;
+  opacity: .5;
+  font-weight: 300;
+  transition-duration: 150ms;
 }
 
 .sidemenu_children {

--- a/src/sidemenu/sidemenu.pcss
+++ b/src/sidemenu/sidemenu.pcss
@@ -18,12 +18,13 @@
   text-decoration: none;
 }
 
-.sidemenu_section, .sidemenu_arrow {
+.sidemenu_section,
+.sidemenu_arrow {
+  flex-grow: 1;
   padding: 0.4rem 0 0.4rem 1rem;
   margin-top: 0.5rem;
   font-weight: bold;
   color: #3f526b;
-  flex-grow: 1;
 }
 
 .sidemenu_child {
@@ -39,13 +40,13 @@
 }
 
 .sidemenu_arrow {
-  padding: 0.4rem 1rem 0.4rem 1rem;
   flex-grow: 0;
-  border-style: none;
-  background: #faf8f5;
-  cursor: pointer;
-  opacity: .5;
+  padding: 0.4rem 1rem;
   font-weight: 300;
+  cursor: pointer;
+  background: #faf8f5;
+  border-style: none;
+  opacity: 0.5;
   transition-duration: 150ms;
 }
 
@@ -55,7 +56,6 @@
 
 .sidemenu_section:hover,
 .sidemenu_child:hover,
-.sidemenu_arrow:hover
-{
+.sidemenu_arrow:hover {
   background: #fff;
 }


### PR DESCRIPTION
API sidemenu indices are collapsible now.

When hovering above `sidemenu_section`, an underline shows up to indicate it's a navigation link. When clicking the blank area, it collpases or expands.

Fixes #271 