### PR TITLE
Enable highlight in API page

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,13 @@
     "postcss-hexrgba": "^2.0.1",
     "postcss-media-minmax": "^5.0.0",
     "postcss-nested": "^5.0.6",
+    "rehype-highlight": "^5.0.2",
+    "rehype-stringify": "^9.0.3",
+    "remark-gfm": "^3.0.1",
     "remark-highlight.js": "^7.0.1",
     "remark-html": "^15.0.1",
     "remark-parse": "^10.0.1",
+    "remark-rehype": "^10.1.0",
     "typedoc": "^0.21.10",
     "typescript": "~4.4.4",
     "unified": "^10.1.2",
@@ -44,6 +48,7 @@
     "eslint-plugin-n": "^15.2.0",
     "eslint-plugin-prefer-let": "^3.0.1",
     "eslint-plugin-promise": "^6.0.0",
+    "highlight.js": "^11.5.1",
     "nano-staged": "^0.8.0",
     "serve": "^13.0.2",
     "simple-git-hooks": "^2.7.0",
@@ -117,7 +122,7 @@
         "dist/api/assets/*",
         "!dist/api/assets/*.ico"
       ],
-      "limit": "300 KB"
+      "limit": "310 KB"
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,20 @@ specifiers:
   eslint-plugin-prefer-let: ^3.0.1
   eslint-plugin-promise: ^6.0.0
   globby: ^13.1.1
+  highlight.js: ^11.5.1
   jstransformer-lowlight: ^0.1.0
   nano-staged: ^0.8.0
   postcss: ^8.4.13
   postcss-hexrgba: ^2.0.1
   postcss-media-minmax: ^5.0.0
   postcss-nested: ^5.0.6
+  rehype-highlight: ^5.0.2
+  rehype-stringify: ^9.0.3
+  remark-gfm: ^3.0.1
   remark-highlight.js: ^7.0.1
   remark-html: ^15.0.1
   remark-parse: ^10.0.1
+  remark-rehype: ^10.1.0
   serve: ^13.0.2
   simple-git-hooks: ^2.7.0
   size-limit: ^7.0.8
@@ -44,9 +49,13 @@ dependencies:
   postcss-hexrgba: 2.0.1
   postcss-media-minmax: 5.0.0_postcss@8.4.13
   postcss-nested: 5.0.6_postcss@8.4.13
+  rehype-highlight: 5.0.2
+  rehype-stringify: 9.0.3
+  remark-gfm: 3.0.1
   remark-highlight.js: 7.0.1
   remark-html: 15.0.1
   remark-parse: 10.0.1
+  remark-rehype: 10.1.0
   typedoc: 0.21.10_typescript@4.4.4
   typescript: 4.4.4
   unified: 10.1.2
@@ -63,6 +72,7 @@ devDependencies:
   eslint-plugin-n: 15.2.0_eslint@8.14.0
   eslint-plugin-prefer-let: 3.0.1
   eslint-plugin-promise: 6.0.0_eslint@8.14.0
+  highlight.js: 11.5.1
   nano-staged: 0.8.0
   serve: 13.0.2
   simple-git-hooks: 2.7.0
@@ -1203,6 +1213,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /escape-string-regexp/5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /eslint-config-standard/17.0.0_csxqpghp2u36zpehgl7g6fmctq:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
@@ -1758,6 +1773,14 @@ packages:
       unist-util-is: 5.1.1
     dev: false
 
+  /hast-util-to-text/3.1.1:
+    resolution: {integrity: sha512-7S3mOBxACy8syL45hCn3J7rHqYaXkxRfsX6LXEU5Shz4nt4GxdjtMUtG+T6G/ZLUHd7kslFAf14kAN71bz30xA==}
+    dependencies:
+      '@types/hast': 2.3.4
+      hast-util-is-element: 2.1.2
+      unist-util-find-after: 4.0.0
+    dev: false
+
   /hast-util-whitespace/1.0.4:
     resolution: {integrity: sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==}
     dev: false
@@ -1773,7 +1796,6 @@ packages:
   /highlight.js/11.5.1:
     resolution: {integrity: sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==}
     engines: {node: '>=12.0.0'}
-    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2151,6 +2173,10 @@ packages:
     resolution: {integrity: sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=}
     dev: true
 
+  /longest-streak/3.0.1:
+    resolution: {integrity: sha512-cHlYSUpL2s7Fb3394mYxwTYj8niTaNHUCLr0qdiCXQfSjfuA7CKofpX2uSwEfFDQ0EB7JcnMnm+GjbqqoinYYg==}
+    dev: false
+
   /lowlight/1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
     dependencies:
@@ -2187,6 +2213,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /markdown-table/3.0.2:
+    resolution: {integrity: sha512-y8j3a5/DkJCmS5x4dMCQL+OR0+2EAq3DOtio1COSHsmW2BGXnNCK3v12hJt1LrUz5iZH5g0LmuYOjDdI+czghA==}
+    dev: false
+
   /marked/4.0.15:
     resolution: {integrity: sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==}
     engines: {node: '>= 12'}
@@ -2203,6 +2233,14 @@ packages:
       '@types/mdast': 3.0.10
       '@types/unist': 2.0.6
       unist-util-visit: 3.1.0
+    dev: false
+
+  /mdast-util-find-and-replace/2.1.0:
+    resolution: {integrity: sha512-1w1jbqAd13oU78QPBf5223+xB+37ecNtQ1JElq2feWols5oEYAl+SgNDnOZipe7NfLemoEt362yUS15/wip4mw==}
+    dependencies:
+      escape-string-regexp: 5.0.0
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 4.1.1
     dev: false
 
   /mdast-util-from-markdown/1.2.0:
@@ -2224,6 +2262,61 @@ packages:
       - supports-color
     dev: false
 
+  /mdast-util-gfm-autolink-literal/1.0.2:
+    resolution: {integrity: sha512-FzopkOd4xTTBeGXhXSBU0OCDDh5lUj2rd+HQqG92Ld+jL4lpUfgX2AT2OHAVP9aEeDKp7G92fuooSZcYJA3cRg==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      ccount: 2.0.1
+      mdast-util-find-and-replace: 2.1.0
+      micromark-util-character: 1.1.0
+    dev: false
+
+  /mdast-util-gfm-footnote/1.0.1:
+    resolution: {integrity: sha512-p+PrYlkw9DeCRkTVw1duWqPRHX6Ywh2BNKJQcZbCwAuP/59B0Lk9kakuAd7KbQprVO4GzdW8eS5++A9PUSqIyw==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+      micromark-util-normalize-identifier: 1.0.0
+    dev: false
+
+  /mdast-util-gfm-strikethrough/1.0.1:
+    resolution: {integrity: sha512-zKJbEPe+JP6EUv0mZ0tQUyLQOC+FADt0bARldONot/nefuISkaZFlmVK4tU6JgfyZGrky02m/I6PmehgAgZgqg==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+    dev: false
+
+  /mdast-util-gfm-table/1.0.4:
+    resolution: {integrity: sha512-aEuoPwZyP4iIMkf2cLWXxx3EQ6Bmh2yKy9MVCg4i6Sd3cX80dcLEfXO/V4ul3pGH9czBK4kp+FAl+ZHmSUt9/w==}
+    dependencies:
+      markdown-table: 3.0.2
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-task-list-item/1.0.1:
+    resolution: {integrity: sha512-KZ4KLmPdABXOsfnM6JHUIjxEvcx2ulk656Z/4Balw071/5qgnhz+H1uGtf2zIGnrnvDC8xR4Fj9uKbjAFGNIeA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-to-markdown: 1.3.0
+    dev: false
+
+  /mdast-util-gfm/2.0.1:
+    resolution: {integrity: sha512-42yHBbfWIFisaAfV1eixlabbsa6q7vHeSPY+cg+BBjX51M8xhgMacqH9g6TftB/9+YkcI0ooV4ncfrJslzm/RQ==}
+    dependencies:
+      mdast-util-from-markdown: 1.2.0
+      mdast-util-gfm-autolink-literal: 1.0.2
+      mdast-util-gfm-footnote: 1.0.1
+      mdast-util-gfm-strikethrough: 1.0.1
+      mdast-util-gfm-table: 1.0.4
+      mdast-util-gfm-task-list-item: 1.0.1
+      mdast-util-to-markdown: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /mdast-util-to-hast/12.1.1:
     resolution: {integrity: sha512-qE09zD6ylVP14jV4mjLIhDBOrpFdShHZcEsYvvKGABlr9mGbV7mTlRWdoFxL/EYSTNDiC9GZXy7y8Shgb9Dtzw==}
     dependencies:
@@ -2237,6 +2330,18 @@ packages:
       unist-util-generated: 2.0.0
       unist-util-position: 4.0.3
       unist-util-visit: 4.1.0
+    dev: false
+
+  /mdast-util-to-markdown/1.3.0:
+    resolution: {integrity: sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
+      longest-streak: 3.0.1
+      mdast-util-to-string: 3.1.0
+      micromark-util-decode-string: 1.0.2
+      unist-util-visit: 4.1.0
+      zwitch: 2.0.2
     dev: false
 
   /mdast-util-to-string/3.1.0:
@@ -2292,6 +2397,79 @@ packages:
       micromark-util-symbol: 1.0.1
       micromark-util-types: 1.0.2
       uvu: 0.5.3
+    dev: false
+
+  /micromark-extension-gfm-autolink-literal/1.0.3:
+    resolution: {integrity: sha512-i3dmvU0htawfWED8aHMMAzAVp/F0Z+0bPh3YrbTPPL1v4YAlCZpy5rBO5p0LPYiZo0zFVkoYh7vDU7yQSiCMjg==}
+    dependencies:
+      micromark-util-character: 1.1.0
+      micromark-util-sanitize-uri: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.3
+    dev: false
+
+  /micromark-extension-gfm-footnote/1.0.4:
+    resolution: {integrity: sha512-E/fmPmDqLiMUP8mLJ8NbJWJ4bTw6tS+FEQS8CcuDtZpILuOb2kjLqPEeAePF1djXROHXChM/wPJw0iS4kHCcIg==}
+    dependencies:
+      micromark-core-commonmark: 1.0.6
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-normalize-identifier: 1.0.0
+      micromark-util-sanitize-uri: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.3
+    dev: false
+
+  /micromark-extension-gfm-strikethrough/1.0.4:
+    resolution: {integrity: sha512-/vjHU/lalmjZCT5xt7CcHVJGq8sYRm80z24qAKXzaHzem/xsDYb2yLL+NNVbYvmpLx3O7SYPuGL5pzusL9CLIQ==}
+    dependencies:
+      micromark-util-chunked: 1.0.0
+      micromark-util-classify-character: 1.0.0
+      micromark-util-resolve-all: 1.0.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.3
+    dev: false
+
+  /micromark-extension-gfm-table/1.0.5:
+    resolution: {integrity: sha512-xAZ8J1X9W9K3JTJTUL7G6wSKhp2ZYHrFk5qJgY/4B33scJzE2kpfRL6oiw/veJTbt7jiM/1rngLlOKPWr1G+vg==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.3
+    dev: false
+
+  /micromark-extension-gfm-tagfilter/1.0.1:
+    resolution: {integrity: sha512-Ty6psLAcAjboRa/UKUbbUcwjVAv5plxmpUTy2XC/3nJFL37eHej8jrHrRzkqcpipJliuBH30DTs7+3wqNcQUVA==}
+    dependencies:
+      micromark-util-types: 1.0.2
+    dev: false
+
+  /micromark-extension-gfm-task-list-item/1.0.3:
+    resolution: {integrity: sha512-PpysK2S1Q/5VXi72IIapbi/jliaiOFzv7THH4amwXeYXLq3l1uo8/2Be0Ac1rEwK20MQEsGH2ltAZLNY2KI/0Q==}
+    dependencies:
+      micromark-factory-space: 1.0.0
+      micromark-util-character: 1.1.0
+      micromark-util-symbol: 1.0.1
+      micromark-util-types: 1.0.2
+      uvu: 0.5.3
+    dev: false
+
+  /micromark-extension-gfm/2.0.1:
+    resolution: {integrity: sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==}
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 1.0.3
+      micromark-extension-gfm-footnote: 1.0.4
+      micromark-extension-gfm-strikethrough: 1.0.4
+      micromark-extension-gfm-table: 1.0.5
+      micromark-extension-gfm-tagfilter: 1.0.1
+      micromark-extension-gfm-task-list-item: 1.0.3
+      micromark-util-combine-extensions: 1.0.0
+      micromark-util-types: 1.0.2
     dev: false
 
   /micromark-factory-destination/1.0.0:
@@ -3074,6 +3252,35 @@ packages:
       rc: 1.2.8
     dev: true
 
+  /rehype-highlight/5.0.2:
+    resolution: {integrity: sha512-ZNm8V8BQUDn05cJPzAu/PjiloaFFrh+Pt3bY+NCcdCggI7Uyl5mW0FGR7RATeIz5/ECUd1D8Kvjt4HaLPmnOMw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      hast-util-to-text: 3.1.1
+      lowlight: 2.6.1
+      unified: 10.1.2
+      unist-util-visit: 4.1.0
+    dev: false
+
+  /rehype-stringify/9.0.3:
+    resolution: {integrity: sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      hast-util-to-html: 8.0.3
+      unified: 10.1.2
+    dev: false
+
+  /remark-gfm/3.0.1:
+    resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
+    dependencies:
+      '@types/mdast': 3.0.10
+      mdast-util-gfm: 2.0.1
+      micromark-extension-gfm: 2.0.1
+      unified: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /remark-highlight.js/7.0.1:
     resolution: {integrity: sha512-ihXPWmg4l55rZ/wREHtEdqXEuVHfE8TvS0UMCemd4lKA1t7ts13xvV3pVLK4vhaeDjSxOroo6U7E4Xxf2wVS4A==}
     dependencies:
@@ -3101,6 +3308,15 @@ packages:
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /remark-rehype/10.1.0:
+    resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
+    dependencies:
+      '@types/hast': 2.3.4
+      '@types/mdast': 3.0.10
+      mdast-util-to-hast: 12.1.1
+      unified: 10.1.2
     dev: false
 
   /require-from-string/2.0.2:
@@ -3702,6 +3918,13 @@ packages:
       '@types/unist': 2.0.6
     dev: false
 
+  /unist-util-find-after/4.0.0:
+    resolution: {integrity: sha512-gfpsxKQde7atVF30n5Gff2fQhAc4/HTOV4CvkXpTg9wRfQhZWdXitpyXHWB6YcYgnsxLx+4gGHeVjCTAAp9sjw==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-is: 5.1.1
+    dev: false
+
   /unist-util-generated/2.0.0:
     resolution: {integrity: sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==}
     dev: false
@@ -3952,3 +4175,7 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
     dev: true
+
+  /zwitch/2.0.2:
+    resolution: {integrity: sha512-JZxotl7SxAJH0j7dN4pxsTV6ZLXoLdGME+PsjkL/DaBrVryK9kTGq06GfKrwcSOqypP+fdXGoCHE36b99fWVoA==}
+    dev: false

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -171,7 +171,7 @@ function toHTML(nodes, markdown) {
     .use(remarkGfm)
     .use(remarkRehype)
     .use(rehypeStringify)
-    .use(rehypeHighlight, { prefix: 'code_' })
+    .use(rehypeHighlight, { prefix: 'code-' })
     .processSync(markdown)
   return String(html)
     .replace(/hljs language-js/g, 'code')

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -171,7 +171,7 @@ function toHTML(nodes, markdown) {
     .use(remarkGfm)
     .use(remarkRehype)
     .use(rehypeStringify)
-    .use(rehypeHighlight)
+    .use(rehypeHighlight, { prefix: 'code_' })
     .processSync(markdown)
   return String(html)
     .replace(/hljs language-js/g, 'code')

--- a/scripts/build-api.js
+++ b/scripts/build-api.js
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
 import {  writeFile, mkdir, rm } from 'fs/promises'
-import remarkHighlight from 'remark-highlight.js'
 import { existsSync } from 'fs'
 import { promisify } from 'util'
 import childProcess from 'child_process'
 import remarkParse from 'remark-parse'
 import { unified } from 'unified'
-import remarkHtml from 'remark-html'
 import { globby } from 'globby'
 import { join } from 'path'
 import TypeDoc from 'typedoc'
 import vite from 'vite'
+import remarkGfm from 'remark-gfm'
+import remarkRehype from 'remark-rehype'
+import rehypeStringify from 'rehype-stringify'
+import rehypeHighlight from 'rehype-highlight'
 
 import { PROJECTS, DIST, SRC } from './lib/dir.js'
 
@@ -64,7 +66,6 @@ async function readTypedoc() {
   for (let file of project.children) {
     nodes.push(...file.children)
   }
-
   return nodes
 }
 
@@ -167,8 +168,10 @@ function toHTML(nodes, markdown) {
   if (!markdown) return ''
   let html = unified()
     .use(remarkParse)
-    .use(remarkHighlight, { prefix: 'code_' })
-    .use(remarkHtml)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeStringify)
+    .use(rehypeHighlight)
     .processSync(markdown)
   return String(html)
     .replace(/hljs language-js/g, 'code')

--- a/src/api.pug
+++ b/src/api.pug
@@ -4,6 +4,7 @@ html( lang="en" )
     include ./base/base.pug
     title PostCSS API
     link( rel="stylesheet" href="./api.pcss" )
+    link( rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css" )
     include ./chat/chat.pug
   body
     main

--- a/src/api.pug
+++ b/src/api.pug
@@ -4,7 +4,6 @@ html( lang="en" )
     include ./base/base.pug
     title PostCSS API
     link( rel="stylesheet" href="./api.pcss" )
-    link( rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/styles/default.min.css" )
     include ./chat/chat.pug
   body
     main

--- a/src/code/code.pcss
+++ b/src/code/code.pcss
@@ -11,3 +11,12 @@
   border: 1px solid #c8c8c8;
   border-radius: 4px;
 }
+
+pre code.code_ {
+  display: block;
+  padding: 0.75rem;
+  overflow-x: auto;
+  background: #fff;
+  border: 1px solid #c8c8c8;
+  border-radius: 4px;
+}

--- a/src/code/code.pcss
+++ b/src/code/code.pcss
@@ -12,7 +12,7 @@
   border-radius: 4px;
 }
 
-pre code.code_ {
+pre .code {
   display: block;
   padding: 0.75rem;
   overflow-x: auto;

--- a/src/code/css.pcss
+++ b/src/code/css.pcss
@@ -1,22 +1,22 @@
 @import "./code.pcss";
 
-.code_highlight {
+.code-highlight {
   display: inline-block;
   padding: 0.125rem;
   margin: 0.125rem 0;
   background: #fff478;
 }
 
-.code_selector-pseudo,
-.code_selector-tag,
-.code_selector-class {
+.code-selector-pseudo,
+.code-selector-tag,
+.code-selector-class {
   color: #c82829;
 }
 
-.code_attribute {
+.code-attribute {
   color: #917100;
 }
 
-.code_number {
+.code-number {
   color: #667e00;
 }

--- a/src/code/js.pcss
+++ b/src/code/js.pcss
@@ -1,18 +1,18 @@
 @import "./code.pcss";
 
-.code_keyword,
-.code_built_in {
+.code-keyword,
+.code-built_in {
   color: #c82829;
 }
 
-.code_attr {
+.code-attr {
   color: #917100;
 }
 
-.code_string {
+.code-string {
   color: #667e00;
 }
 
-.code_comment {
+.code-comment {
   color: #757772;
 }

--- a/src/doc/doc.pcss
+++ b/src/doc/doc.pcss
@@ -20,6 +20,10 @@
   }
 }
 
+.doc:first-of-type {
+  padding-top: 4rem;
+}
+
 .doc_title,
 .doc_subtitle {
   margin-bottom: 1rem;

--- a/src/features/features.pug
+++ b/src/features/features.pug
@@ -9,13 +9,13 @@ section.feature
     .feature_example
       figure.example
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             :fullscreen {
             }
         figcaption.example_caption CSS input
       figure.example.is-out
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             :-webkit-full-screen {
             }
             :-ms-fullscreen {
@@ -35,14 +35,14 @@ section.feature.is-alt
     .feature_example
       figure.example
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             body {
               color: lch(53 105 40);
             }
         figcaption.example_caption CSS input
       figure.example.is-out
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             body {
               color: rgb(250, 0, 4);
             }
@@ -59,14 +59,14 @@ section.feature
     .feature_example
       figure.example
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             .name {
               color: gray;
             }
         figcaption.example_caption CSS input
       figure.example.is-out
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             .Logo__name__SVK0g {
               color: gray;
             }
@@ -83,14 +83,14 @@ section.feature.is-alt
     .feature_example
       figure.example
         pre.code
-          :lowlight( lang="css" prefix="code_" )
+          :lowlight( lang="css" prefix="code-" )
             a {
               color: #d3;
             }
         figcaption.example_caption CSS input
       figure.example.is-out
         pre.code
-          :lowlight( prefix="code_" )
+          :lowlight( prefix="code-" )
             app.css
             2:10 Invalid hex color
         figcaption.example_caption Console output


### PR DESCRIPTION
1. Replace deprecated [remark-highlight.js](https://github.com/remarkjs/remark-highlight.js?files=1) with [rehype-highlight](https://github.com/rehypejs/rehype-highlight).
2. Enable code highlight in API page.
3. Adjust doc padding so that navigation bar does not cover doc content.
4. Increase API package limit from 300kb to 310kb (Is that permissible?)