### PR TITLE
`http://postcss.parts/` => `https://www.postcss.parts/`

### DIFF
--- a/src/nav/nav.pug
+++ b/src/nav/nav.pug
@@ -7,7 +7,7 @@ nav.nav
       a.nav_link( href="https://github.com/postcss/postcss/tree/main/docs" )
         | Docs
     li.nav_item
-      a.nav_link( href="http://postcss.parts/" )
+      a.nav_link( href="https://www.postcss.parts/" )
         | Plugins
     li.nav_item
       a.nav_link( href="/api/" )

--- a/src/way/way.pug
+++ b/src/way/way.pug
@@ -10,7 +10,7 @@ nav.way
       a.way_link( href="https://github.com/postcss/postcss#articles" )
         | Learn
     li.way_item
-      a.way_link( href="http://postcss.parts/" )
+      a.way_link( href="https://www.postcss.parts/" )
         | Plugins
     li.way_item
       a.way_link( href="https://opencollective.com/postcss/" )


### PR DESCRIPTION
For me, on firefox, links cannot be open. https://postcss.parts/ cannot be open too.