### PR TITLE
Switch from lch() to oklch() CSS function in postcss-preset-env example

### DIFF
--- a/src/features/features.pug
+++ b/src/features/features.pug
@@ -37,14 +37,14 @@ section.feature.is-alt
         pre.code
           :lowlight( lang="css" prefix="code-" )
             body {
-              color: lch(53 105 40);
+              color: oklch(53% 105 40);
             }
         figcaption.example_caption CSS input
       figure.example.is-out
         pre.code
           :lowlight( lang="css" prefix="code-" )
             body {
-              color: rgb(250, 0, 4);
+              color: rgb(193, 45, 0);
             }
         figcaption.example_caption CSS output
 


### PR DESCRIPTION
Also looks like current `lch(53 105 40);` color in example is not valid